### PR TITLE
Increasing Psy Shell  version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.4.0",
     "yiisoft/yii2": "*",
     "symfony/var-dumper": "4.2.0",
-    "psy/psysh": "0.9.9"
+    "psy/psysh": "0.10.5"
   },
   "autoload": {
     "psr-4": {"Yii2Tinker\\": "src/"}


### PR DESCRIPTION
`New version is available (current: v0.9.9, latest: v0.10.5)`
